### PR TITLE
Mock-able time.

### DIFF
--- a/backend/utils/time.js
+++ b/backend/utils/time.js
@@ -1,0 +1,28 @@
+/**
+ * Util that allows me to get current time in a test safe manner.
+ */
+class Time{
+    constructor(){
+        /** 
+         * Set this property to overwrite the time for now. Only useful for testing.
+         *  
+         * @type {Date?} 
+         */
+        this.nowOverride = undefined;
+    }
+    
+    /** 
+     * Returns the Date object for now. Or the override if its set.
+     * 
+     * @returns {Date}
+     */
+    now() {
+        if(this.nowOverride !== undefined) {
+            return this.nowOverride;
+        } else {
+            return new Date();
+        }
+    }
+}
+
+module.exports = Time;

--- a/backend/utils/time.test.js
+++ b/backend/utils/time.test.js
@@ -1,0 +1,15 @@
+const Time = require('./time');
+
+test('Returns current time.', () => {
+    let time = new Time();
+    let now = time.now();
+    let past = new Date(2020, 1, 1);
+    expect(now.getTime()).toBeGreaterThan(past.getTime());
+})
+
+test('Overwrite now.', () => {
+    let override = new Date(2020, 1, 1);
+    let time = new Time();
+    time.nowOverride = override;
+    expect(time.now()).toEqual(override);
+})


### PR DESCRIPTION
I would like to unit test the device auth code. But time and unit testing do not mix. 

Its very easy to create flaky tests that only work sometimes. (Literally in this case).

So i have create this small class that allows me to override the current time for my code so that test tokens expire in 60 sec without having tests that need over 60 sec to run.