### PR TITLE
Add more gamepad buttons

### DIFF
--- a/public/gamepad.js
+++ b/public/gamepad.js
@@ -2,11 +2,11 @@ export default class GamePad {
 
     /** Gets the axis of the first gamepad connected 
      * 
-     * @returns {[number]} An array of values between -1 and 1 for etch axis supposed by the controller.
+     * @returns The axes and buttons available for the connected gamepad controller.
+     * These are returned in two separate arrays.
+     * If no gamepad is detected, return null.
      */
     getGamepad() {
-        //TODO need to handle the case where there is no gamepad connected. This function should return something useful like an axes of only 0.0
-
         let gamepads = navigator.getGamepads ? navigator.getGamepads() : (navigator.webkitGetGamepads ? navigator.webkitGetGamepads : []);
         if (gamepads[0] !== null)
             return [gamepads[0].axes, gamepads[0].buttons];

--- a/public/gamepad.js
+++ b/public/gamepad.js
@@ -4,10 +4,12 @@ export default class GamePad {
      * 
      * @returns {[number]} An array of values between -1 and 1 for etch axis supposed by the controller.
      */
-    getAxes() {
+    getGamepad() {
         //TODO need to handle the case where there is no gamepad connected. This function should return something useful like an axes of only 0.0
 
         let gamepads = navigator.getGamepads ? navigator.getGamepads() : (navigator.webkitGetGamepads ? navigator.webkitGetGamepads : []);
-        return gamepads[0].axes;
+        if (gamepads[0] !== null)
+            return [gamepads[0].axes, gamepads[0].buttons];
+        return null;
     }
 }

--- a/public/input.js
+++ b/public/input.js
@@ -114,6 +114,7 @@ export default class Input{
 
         if (this.flightMode !== this.prevFlightMode) {
             this._websocket.sendShuttleCommand('changeFlightMode', this.flightMode);
+            this.prevFlightMode = this.flightMode;
         }
     }
 }

--- a/public/input.js
+++ b/public/input.js
@@ -18,9 +18,9 @@ export default class Input{
         this.flightMode = null;
         this.prevFlightMode = null;
         this.flightModes = {
-            MANUAL = 'MANUAL',
-            STABILIZE = 'STABILIZE',
-            DEPTH_HOLD = 'DEPTH_HOLD'
+            MANUAL: 'MANUAL',
+            STABILIZE: 'STABILIZE',
+            DEPTH_HOLD: 'DEPTH_HOLD'
         }
     }
 


### PR DESCRIPTION
Added buttons for arming/disarming the shuttle and for changing the shuttle's flight mode. On a PS4 controller, the buttons are mapped as such: 
`X` = `'MANUAL' flight mode`
`Circle` = `'STABILIZE' flight mode`
`Square` = `'DEPTH_HOLD' flight mode`
`R1` = `Arm shuttle`
`L1` = `Disarm shuttle`
The buttons may be mapped to other functions later, if necessary. 

Also added some exception handling in the frontend.