### PR TITLE
Device authentication

### DIFF
--- a/backend/config.js
+++ b/backend/config.js
@@ -4,7 +4,7 @@ class Config {
     constructor(){
         this._port = 3000;
         this._baseUrl = new URL("http://localhost:3000/");
-        this._disableDeviceAuth = true;
+        this._disableDeviceAuth = false;
         this._iotHubConnectionString = "";
         this._iotHubStreamDevices = "";
         this._eventHubConnectionString = "";

--- a/backend/express.js
+++ b/backend/express.js
@@ -31,8 +31,6 @@ class Express {
         if (path[1] === 'browser') { 
             this.browserWs.handleUpgrade({}, request, socket, head);
         } else if (path[1] === 'device') {
-            let token = this.auth.getDeviceToken(path[2]);
-            request.headers.authorization = token.authorization;
             if(this.auth.validateDeviceRequest(path[2], request)) {
                 this.deviceWs.handleUpgrade(path[2], request, socket, head);
             }else{

--- a/backend/express.js
+++ b/backend/express.js
@@ -31,6 +31,8 @@ class Express {
         if (path[1] === 'browser') { 
             this.browserWs.handleUpgrade({}, request, socket, head);
         } else if (path[1] === 'device') {
+            let token = this.auth.getDeviceToken(path[2]);
+            request.headers.authorization = token.authorization;
             if(this.auth.validateDeviceRequest(path[2], request)) {
                 this.deviceWs.handleUpgrade(path[2], request, socket, head);
             }else{

--- a/backend/index.js
+++ b/backend/index.js
@@ -40,7 +40,7 @@ function main() {
     const azureIot = new AzureIot(config);
 
     //Setup ShuttleControl
-    const shuttleControl = new ShuttleControl(azureIot, browserWs, deviceWs);
+    const shuttleControl = new ShuttleControl(azureIot, browserWs, deviceWs, auth);
 
     //Setup ShuttleTelemetry
     const shuttleTelemetry = new ShuttleTelemetry(azureIot, browserWs, deviceWs);

--- a/backend/shuttle-control.js
+++ b/backend/shuttle-control.js
@@ -10,8 +10,13 @@ class ShuttleControl {
     start() {
         let self = this;
 
-        let token = self.auth.getDeviceToken('shuttle');
-        self.azureIot.sendMessage('shuttle',token);
+        self.azureIot.onMessage('shuttle', function (message) {
+            let messageType = message.systemProperties.messageId;
+            if (messageType === 'requestToken') {
+                let token = self.auth.getDeviceToken('shuttle');
+                self.azureIot.sendMessage('shuttle',token);
+            }
+        });
         
         // Listens for all websocket messages with type 'input'
         self.browserWs.onTopic('input', function (message) {

--- a/backend/shuttle-control.js
+++ b/backend/shuttle-control.js
@@ -8,6 +8,8 @@ class ShuttleControl {
 
     start() {
         let self = this;
+        let token = this.auth.getDeviceToken('shuttle');
+        this.azureIot.sendMessage('shuttle',token);
         // Listens for all websocket messages with type 'input'
         self.browserWs.onTopic('input', function (message) {
 

--- a/backend/shuttle-control.js
+++ b/backend/shuttle-control.js
@@ -1,15 +1,18 @@
 class ShuttleControl {
-    constructor(azureIot, browserWs, deviceWs) {
+    constructor(azureIot, browserWs, deviceWs, auth) {
         this.azureIot = azureIot;
         this.browserWs = browserWs;
         this.deviceWs = deviceWs;
+        this.auth = auth;
         this.currentBrowser = null;
     }
 
     start() {
         let self = this;
-        let token = this.auth.getDeviceToken('shuttle');
-        this.azureIot.sendMessage('shuttle',token);
+
+        let token = self.auth.getDeviceToken('shuttle');
+        self.azureIot.sendMessage('shuttle',token);
+        
         // Listens for all websocket messages with type 'input'
         self.browserWs.onTopic('input', function (message) {
 

--- a/devices/Shuttle/poetry.lock
+++ b/devices/Shuttle/poetry.lock
@@ -30,6 +30,45 @@ docs = ["sphinx", "zope.interface"]
 tests = ["coverage", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface"]
 
 [[package]]
+category = "main"
+description = "Microsoft Azure IoT Device Library"
+name = "azure-iot-device"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3*, <4"
+version = "2.1.4"
+
+[package.dependencies]
+PySocks = "*"
+paho-mqtt = ">=1.4.0,<2.0.0"
+requests = ">=2.20.0,<3.0.0"
+requests-unixsocket = ">=0.1.5,<1.0.0"
+six = ">=1.12.0,<2.0.0"
+
+[package.dependencies.janus]
+python = ">=3.5"
+version = "0.4.0"
+
+[package.dependencies.urllib3]
+python = "<3.4.0 || >=3.5.0"
+version = ">1.21.1,<1.25.0 || >1.25.0,<1.25.1 || >1.25.1,<1.26"
+
+[[package]]
+category = "main"
+description = "Python package for providing Mozilla's CA Bundle."
+name = "certifi"
+optional = false
+python-versions = "*"
+version = "2020.6.20"
+
+[[package]]
+category = "main"
+description = "Universal encoding detector for Python 2 and 3"
+name = "chardet"
+optional = false
+python-versions = "*"
+version = "3.0.4"
+
+[[package]]
 category = "dev"
 description = "Cross-platform colored terminal text."
 marker = "sys_platform == \"win32\""
@@ -48,11 +87,28 @@ version = "0.18.2"
 
 [[package]]
 category = "main"
+description = "Internationalized Domain Names in Applications (IDNA)"
+name = "idna"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "2.10"
+
+[[package]]
+category = "main"
+description = "Mixed sync-async queue to interoperate between asyncio tasks and classic threads"
+marker = "python_version >= \"3.5\""
+name = "janus"
+optional = false
+python-versions = ">=3.5.3"
+version = "0.4.0"
+
+[[package]]
+category = "main"
 description = "Powerful and Pythonic XML processing library combining libxml2/libxslt with the ElementTree API."
 name = "lxml"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, != 3.4.*"
-version = "4.5.1"
+version = "4.5.2"
 
 [package.extras]
 cssselect = ["cssselect (>=0.7)"]
@@ -79,6 +135,17 @@ version = "20.4"
 [package.dependencies]
 pyparsing = ">=2.0.2"
 six = "*"
+
+[[package]]
+category = "main"
+description = "MQTT version 3.1.1 client class"
+name = "paho-mqtt"
+optional = false
+python-versions = "*"
+version = "1.5.0"
+
+[package.extras]
+proxy = ["pysocks"]
 
 [[package]]
 category = "dev"
@@ -120,6 +187,14 @@ python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 version = "2.4.7"
 
 [[package]]
+category = "main"
+description = "A Python SOCKS client module. See https://github.com/Anorov/PySocks for more information."
+name = "pysocks"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "1.7.1"
+
+[[package]]
 category = "dev"
 description = "pytest: simple powerful testing with Python"
 name = "pytest"
@@ -153,12 +228,55 @@ version = "0.13.0"
 cli = ["click (>=5.0)"]
 
 [[package]]
-category = "dev"
+category = "main"
+description = "Python HTTP for Humans."
+name = "requests"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+version = "2.24.0"
+
+[package.dependencies]
+certifi = ">=2017.4.17"
+chardet = ">=3.0.2,<4"
+idna = ">=2.5,<3"
+urllib3 = ">=1.21.1,<1.25.0 || >1.25.0,<1.25.1 || >1.25.1,<1.26"
+
+[package.extras]
+security = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)"]
+socks = ["PySocks (>=1.5.6,<1.5.7 || >1.5.7)", "win-inet-pton"]
+
+[[package]]
+category = "main"
+description = "Use requests to talk HTTP via a UNIX domain socket"
+name = "requests-unixsocket"
+optional = false
+python-versions = "*"
+version = "0.2.0"
+
+[package.dependencies]
+requests = ">=1.1"
+urllib3 = ">=1.8"
+
+[[package]]
+category = "main"
 description = "Python 2 and 3 compatibility utilities"
 name = "six"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
 version = "1.15.0"
+
+[[package]]
+category = "main"
+description = "HTTP library with thread-safe connection pooling, file post, and more."
+name = "urllib3"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
+version = "1.25.10"
+
+[package.extras]
+brotli = ["brotlipy (>=0.6.0)"]
+secure = ["certifi", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "pyOpenSSL (>=0.14)", "ipaddress"]
+socks = ["PySocks (>=1.5.6,<1.5.7 || >1.5.7,<2.0)"]
 
 [[package]]
 category = "dev"
@@ -177,7 +295,7 @@ python-versions = ">=3.6.1"
 version = "8.1"
 
 [metadata]
-content-hash = "5447151f7732a16fbb813f87dc2c20a90951b3d1801fbefbff7c436fedce5f11"
+content-hash = "35c3c81ac3d70028ca54c4792067d8b21865ee9e672623b13b84b3c146ac58c0"
 python-versions = "^3.8"
 
 [metadata.files]
@@ -195,6 +313,18 @@ attrs = [
     {file = "attrs-19.3.0-py2.py3-none-any.whl", hash = "sha256:08a96c641c3a74e44eb59afb61a24f2cb9f4d7188748e76ba4bb5edfa3cb7d1c"},
     {file = "attrs-19.3.0.tar.gz", hash = "sha256:f7b7ce16570fe9965acd6d30101a28f62fb4a7f9e926b3bbc9b61f8b04247e72"},
 ]
+azure-iot-device = [
+    {file = "azure-iot-device-2.1.4.tar.gz", hash = "sha256:232c8816655b2b3aa0ff16b644325ee9ec405441869c985a9e0681dd834db95e"},
+    {file = "azure_iot_device-2.1.4-py2.py3-none-any.whl", hash = "sha256:916ae7545cbaa0000af1079dbb39b9bc272ba1ee70319ccd224d08ad8bd4f16c"},
+]
+certifi = [
+    {file = "certifi-2020.6.20-py2.py3-none-any.whl", hash = "sha256:8fc0819f1f30ba15bdb34cceffb9ef04d99f420f68eb75d901e9560b8749fc41"},
+    {file = "certifi-2020.6.20.tar.gz", hash = "sha256:5930595817496dd21bb8dc35dad090f1c2cd0adfaf21204bf6732ca5d8ee34d3"},
+]
+chardet = [
+    {file = "chardet-3.0.4-py2.py3-none-any.whl", hash = "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"},
+    {file = "chardet-3.0.4.tar.gz", hash = "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae"},
+]
 colorama = [
     {file = "colorama-0.4.3-py2.py3-none-any.whl", hash = "sha256:7d73d2a99753107a36ac6b455ee49046802e59d9d076ef8e47b61499fa29afff"},
     {file = "colorama-0.4.3.tar.gz", hash = "sha256:e96da0d330793e2cb9485e9ddfd918d456036c7149416295932478192f4436a1"},
@@ -202,34 +332,46 @@ colorama = [
 future = [
     {file = "future-0.18.2.tar.gz", hash = "sha256:b1bead90b70cf6ec3f0710ae53a525360fa360d306a86583adc6bf83a4db537d"},
 ]
+idna = [
+    {file = "idna-2.10-py2.py3-none-any.whl", hash = "sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0"},
+    {file = "idna-2.10.tar.gz", hash = "sha256:b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6"},
+]
+janus = [
+    {file = "janus-0.4.0-py3-none-any.whl", hash = "sha256:86878806559274376b83193bfd992ad94576d1024ddfc69cf1a908bf20d6b37d"},
+    {file = "janus-0.4.0.tar.gz", hash = "sha256:cfc221683160b91b35bae1917e2957b78dad10a2e634f4f8ed119ed72e2a88ef"},
+]
 lxml = [
-    {file = "lxml-4.5.1-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:ee2be8b8f72a2772e72ab926a3bccebf47bb727bda41ae070dc91d1fb759b726"},
-    {file = "lxml-4.5.1-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:fadd2a63a2bfd7fb604508e553d1cf68eca250b2fbdbd81213b5f6f2fbf23529"},
-    {file = "lxml-4.5.1-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:4f282737d187ae723b2633856085c31ae5d4d432968b7f3f478a48a54835f5c4"},
-    {file = "lxml-4.5.1-cp27-cp27m-win32.whl", hash = "sha256:7fd88cb91a470b383aafad554c3fe1ccf6dfb2456ff0e84b95335d582a799804"},
-    {file = "lxml-4.5.1-cp27-cp27m-win_amd64.whl", hash = "sha256:0790ddca3f825dd914978c94c2545dbea5f56f008b050e835403714babe62a5f"},
-    {file = "lxml-4.5.1-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:9144ce36ca0824b29ebc2e02ca186e54040ebb224292072250467190fb613b96"},
-    {file = "lxml-4.5.1-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:a636346c6c0e1092ffc202d97ec1843a75937d8c98aaf6771348ad6422e44bb0"},
-    {file = "lxml-4.5.1-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:f95d28193c3863132b1f55c1056036bf580b5a488d908f7d22a04ace8935a3a9"},
-    {file = "lxml-4.5.1-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:b26719890c79a1dae7d53acac5f089d66fd8cc68a81f4e4bd355e45470dc25e1"},
-    {file = "lxml-4.5.1-cp35-cp35m-win32.whl", hash = "sha256:a9e3b8011388e7e373565daa5e92f6c9cb844790dc18e43073212bb3e76f7007"},
-    {file = "lxml-4.5.1-cp35-cp35m-win_amd64.whl", hash = "sha256:2754d4406438c83144f9ffd3628bbe2dcc6d62b20dbc5c1ec4bc4385e5d44b42"},
-    {file = "lxml-4.5.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:925baf6ff1ef2c45169f548cc85204433e061360bfa7d01e1be7ae38bef73194"},
-    {file = "lxml-4.5.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:a87dbee7ad9dce3aaefada2081843caf08a44a8f52e03e0a4cc5819f8398f2f4"},
-    {file = "lxml-4.5.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:51bb4edeb36d24ec97eb3e6a6007be128b720114f9a875d6b370317d62ac80b9"},
-    {file = "lxml-4.5.1-cp36-cp36m-win32.whl", hash = "sha256:c79e5debbe092e3c93ca4aee44c9a7631bdd407b2871cb541b979fd350bbbc29"},
-    {file = "lxml-4.5.1-cp36-cp36m-win_amd64.whl", hash = "sha256:b7462cdab6fffcda853338e1741ce99706cdf880d921b5a769202ea7b94e8528"},
-    {file = "lxml-4.5.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:06748c7192eab0f48e3d35a7adae609a329c6257495d5e53878003660dc0fec6"},
-    {file = "lxml-4.5.1-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:1aa7a6197c1cdd65d974f3e4953764eee3d9c7b67e3966616b41fab7f8f516b7"},
-    {file = "lxml-4.5.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:afb53edf1046599991fb4a7d03e601ab5f5422a5435c47ee6ba91ec3b61416a6"},
-    {file = "lxml-4.5.1-cp37-cp37m-win32.whl", hash = "sha256:2d1ddce96cf15f1254a68dba6935e6e0f1fe39247de631c115e84dd404a6f031"},
-    {file = "lxml-4.5.1-cp37-cp37m-win_amd64.whl", hash = "sha256:22c6d34fdb0e65d5f782a4d1a1edb52e0a8365858dafb1c08cb1d16546cf0786"},
-    {file = "lxml-4.5.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:c47a8a5d00060122ca5908909478abce7bbf62d812e3fc35c6c802df8fb01fe7"},
-    {file = "lxml-4.5.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:b77975465234ff49fdad871c08aa747aae06f5e5be62866595057c43f8d2f62c"},
-    {file = "lxml-4.5.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:2b02c106709466a93ed424454ce4c970791c486d5fcdf52b0d822a7e29789626"},
-    {file = "lxml-4.5.1-cp38-cp38-win32.whl", hash = "sha256:7eee37c1b9815e6505847aa5e68f192e8a1b730c5c7ead39ff317fde9ce29448"},
-    {file = "lxml-4.5.1-cp38-cp38-win_amd64.whl", hash = "sha256:d8d40e0121ca1606aa9e78c28a3a7d88a05c06b3ca61630242cded87d8ce55fa"},
-    {file = "lxml-4.5.1.tar.gz", hash = "sha256:27ee0faf8077c7c1a589573b1450743011117f1aa1a91d5ae776bbc5ca6070f2"},
+    {file = "lxml-4.5.2-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:74f48ec98430e06c1fa8949b49ebdd8d27ceb9df8d3d1c92e1fdc2773f003f20"},
+    {file = "lxml-4.5.2-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:e70d4e467e243455492f5de463b72151cc400710ac03a0678206a5f27e79ddef"},
+    {file = "lxml-4.5.2-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:7ad7906e098ccd30d8f7068030a0b16668ab8aa5cda6fcd5146d8d20cbaa71b5"},
+    {file = "lxml-4.5.2-cp27-cp27m-win32.whl", hash = "sha256:92282c83547a9add85ad658143c76a64a8d339028926d7dc1998ca029c88ea6a"},
+    {file = "lxml-4.5.2-cp27-cp27m-win_amd64.whl", hash = "sha256:05a444b207901a68a6526948c7cc8f9fe6d6f24c70781488e32fd74ff5996e3f"},
+    {file = "lxml-4.5.2-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:94150231f1e90c9595ccc80d7d2006c61f90a5995db82bccbca7944fd457f0f6"},
+    {file = "lxml-4.5.2-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:bea760a63ce9bba566c23f726d72b3c0250e2fa2569909e2d83cda1534c79443"},
+    {file = "lxml-4.5.2-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:c3f511a3c58676147c277eff0224c061dd5a6a8e1373572ac817ac6324f1b1e0"},
+    {file = "lxml-4.5.2-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:59daa84aef650b11bccd18f99f64bfe44b9f14a08a28259959d33676554065a1"},
+    {file = "lxml-4.5.2-cp35-cp35m-manylinux2014_aarch64.whl", hash = "sha256:c9d317efde4bafbc1561509bfa8a23c5cab66c44d49ab5b63ff690f5159b2304"},
+    {file = "lxml-4.5.2-cp35-cp35m-win32.whl", hash = "sha256:9dc9006dcc47e00a8a6a029eb035c8f696ad38e40a27d073a003d7d1443f5d88"},
+    {file = "lxml-4.5.2-cp35-cp35m-win_amd64.whl", hash = "sha256:08fc93257dcfe9542c0a6883a25ba4971d78297f63d7a5a26ffa34861ca78730"},
+    {file = "lxml-4.5.2-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:121b665b04083a1e85ff1f5243d4a93aa1aaba281bc12ea334d5a187278ceaf1"},
+    {file = "lxml-4.5.2-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:5591c4164755778e29e69b86e425880f852464a21c7bb53c7ea453bbe2633bbe"},
+    {file = "lxml-4.5.2-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:cc411ad324a4486b142c41d9b2b6a722c534096963688d879ea6fa8a35028258"},
+    {file = "lxml-4.5.2-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:1fa21263c3aba2b76fd7c45713d4428dbcc7644d73dcf0650e9d344e433741b3"},
+    {file = "lxml-4.5.2-cp36-cp36m-win32.whl", hash = "sha256:786aad2aa20de3dbff21aab86b2fb6a7be68064cbbc0219bde414d3a30aa47ae"},
+    {file = "lxml-4.5.2-cp36-cp36m-win_amd64.whl", hash = "sha256:e1cacf4796b20865789083252186ce9dc6cc59eca0c2e79cca332bdff24ac481"},
+    {file = "lxml-4.5.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:80a38b188d20c0524fe8959c8ce770a8fdf0e617c6912d23fc97c68301bb9aba"},
+    {file = "lxml-4.5.2-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:ecc930ae559ea8a43377e8b60ca6f8d61ac532fc57efb915d899de4a67928efd"},
+    {file = "lxml-4.5.2-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:a76979f728dd845655026ab991df25d26379a1a8fc1e9e68e25c7eda43004bed"},
+    {file = "lxml-4.5.2-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:cfd7c5dd3c35c19cec59c63df9571c67c6d6e5c92e0fe63517920e97f61106d1"},
+    {file = "lxml-4.5.2-cp37-cp37m-win32.whl", hash = "sha256:5a9c8d11aa2c8f8b6043d845927a51eb9102eb558e3f936df494e96393f5fd3e"},
+    {file = "lxml-4.5.2-cp37-cp37m-win_amd64.whl", hash = "sha256:4b4a111bcf4b9c948e020fd207f915c24a6de3f1adc7682a2d92660eb4e84f1a"},
+    {file = "lxml-4.5.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:5dd20538a60c4cc9a077d3b715bb42307239fcd25ef1ca7286775f95e9e9a46d"},
+    {file = "lxml-4.5.2-cp38-cp38-manylinux1_i686.whl", hash = "sha256:2b30aa2bcff8e958cd85d907d5109820b01ac511eae5b460803430a7404e34d7"},
+    {file = "lxml-4.5.2-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:aa8eba3db3d8761db161003e2d0586608092e217151d7458206e243be5a43843"},
+    {file = "lxml-4.5.2-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:8f0ec6b9b3832e0bd1d57af41f9238ea7709bbd7271f639024f2fc9d3bb01293"},
+    {file = "lxml-4.5.2-cp38-cp38-win32.whl", hash = "sha256:107781b213cf7201ec3806555657ccda67b1fccc4261fb889ef7fc56976db81f"},
+    {file = "lxml-4.5.2-cp38-cp38-win_amd64.whl", hash = "sha256:f161af26f596131b63b236372e4ce40f3167c1b5b5d459b29d2514bd8c9dc9ee"},
+    {file = "lxml-4.5.2.tar.gz", hash = "sha256:cdc13a1682b2a6241080745b1953719e7fe0850b40a5c71ca574f090a1391df6"},
 ]
 more-itertools = [
     {file = "more-itertools-8.4.0.tar.gz", hash = "sha256:68c70cc7167bdf5c7c9d8f6954a7837089c6a36bf565383919bb595efb8a17e5"},
@@ -238,6 +380,9 @@ more-itertools = [
 packaging = [
     {file = "packaging-20.4-py2.py3-none-any.whl", hash = "sha256:998416ba6962ae7fbd6596850b80e17859a5753ba17c32284f67bfff33784181"},
     {file = "packaging-20.4.tar.gz", hash = "sha256:4357f74f47b9c12db93624a82154e9b120fa8293699949152b22065d556079f8"},
+]
+paho-mqtt = [
+    {file = "paho-mqtt-1.5.0.tar.gz", hash = "sha256:e3d286198baaea195c8b3bc221941d25a3ab0e1507fc1779bdb7473806394be4"},
 ]
 pluggy = [
     {file = "pluggy-0.13.1-py2.py3-none-any.whl", hash = "sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d"},
@@ -254,6 +399,11 @@ pyparsing = [
     {file = "pyparsing-2.4.7-py2.py3-none-any.whl", hash = "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"},
     {file = "pyparsing-2.4.7.tar.gz", hash = "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1"},
 ]
+pysocks = [
+    {file = "PySocks-1.7.1-py27-none-any.whl", hash = "sha256:08e69f092cc6dbe92a0fdd16eeb9b9ffbc13cadfe5ca4c7bd92ffb078b293299"},
+    {file = "PySocks-1.7.1-py3-none-any.whl", hash = "sha256:2725bd0a9925919b9b51739eea5f9e2bae91e83288108a9ad338b2e3a4435ee5"},
+    {file = "PySocks-1.7.1.tar.gz", hash = "sha256:3f8804571ebe159c380ac6de37643bb4685970655d3bba243530d6558b799aa0"},
+]
 pytest = [
     {file = "pytest-5.4.3-py3-none-any.whl", hash = "sha256:5c0db86b698e8f170ba4582a492248919255fcd4c79b1ee64ace34301fb589a1"},
     {file = "pytest-5.4.3.tar.gz", hash = "sha256:7979331bfcba207414f5e1263b5a0f8f521d0f457318836a7355531ed1a4c7d8"},
@@ -262,9 +412,21 @@ python-dotenv = [
     {file = "python-dotenv-0.13.0.tar.gz", hash = "sha256:3b9909bc96b0edc6b01586e1eed05e71174ef4e04c71da5786370cebea53ad74"},
     {file = "python_dotenv-0.13.0-py2.py3-none-any.whl", hash = "sha256:25c0ff1a3e12f4bde8d592cc254ab075cfe734fc5dd989036716fd17ee7e5ec7"},
 ]
+requests = [
+    {file = "requests-2.24.0-py2.py3-none-any.whl", hash = "sha256:fe75cc94a9443b9246fc7049224f75604b113c36acb93f87b80ed42c44cbb898"},
+    {file = "requests-2.24.0.tar.gz", hash = "sha256:b3559a131db72c33ee969480840fff4bb6dd111de7dd27c8ee1f820f4f00231b"},
+]
+requests-unixsocket = [
+    {file = "requests-unixsocket-0.2.0.tar.gz", hash = "sha256:9e5c1a20afc3cf786197ae59c79bcdb0e7565f218f27df5f891307ee8817c1ea"},
+    {file = "requests_unixsocket-0.2.0-py2.py3-none-any.whl", hash = "sha256:014d07bfb66dc805a011a8b4b306cf4ec96d2eddb589f6b2b5765e626f0dc0cc"},
+]
 six = [
     {file = "six-1.15.0-py2.py3-none-any.whl", hash = "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"},
     {file = "six-1.15.0.tar.gz", hash = "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259"},
+]
+urllib3 = [
+    {file = "urllib3-1.25.10-py2.py3-none-any.whl", hash = "sha256:e7983572181f5e1522d9c98453462384ee92a0be7fac5f1413a1e35c56cc0461"},
+    {file = "urllib3-1.25.10.tar.gz", hash = "sha256:91056c15fa70756691db97756772bb1eb9678fa585d9184f24534b100dc60f4a"},
 ]
 wcwidth = [
     {file = "wcwidth-0.2.5-py2.py3-none-any.whl", hash = "sha256:beb4802a9cebb9144e99086eff703a642a13d6a0052920003a230f3294bbe784"},

--- a/devices/Shuttle/pyproject.toml
+++ b/devices/Shuttle/pyproject.toml
@@ -15,6 +15,7 @@ pymavlink = "^2.4.9"
 python-dotenv = "^0.13.0"
 websockets = "^8.1"
 asyncio = "^3.4.3"
+azure-iot-device = "^2.1.4"
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.2"

--- a/devices/Shuttle/shuttle/azure_messages.py
+++ b/devices/Shuttle/shuttle/azure_messages.py
@@ -1,7 +1,7 @@
-from azure.iot.device import IoTHubDeviceClient
+from azure.iot.device import IoTHubDeviceClient, Message
 import json
 
-class AzureMessageListener:
+class AzureMessages:
 
     def __init__(self, connection_string):
         self.connection_string = connection_string
@@ -10,6 +10,15 @@ class AzureMessageListener:
         self.device_client.connect()
 
     def message_listener(self):
-        message = self.device_client.receive_message()  # blocking call
-        jsonMsg = json.loads(message.data)
-        return jsonMsg['url'], jsonMsg['authorization']
+        '''Listens for all messages sent to the shuttle from the Azure IoT Hub.
+        Returns a'''
+        while True:
+            message = self.device_client.receive_message()  # blocking call
+            jsonMsg = json.loads(message.data)
+            if 'url' in jsonMsg and 'authorization' in jsonMsg:
+                return jsonMsg['url'], jsonMsg['authorization']
+
+    def send_message(self, message_type, message_data):
+        message = Message(message_data)
+        message.message_id = message_type
+        self.device_client.send_message(message)

--- a/devices/Shuttle/shuttle/azure_messages.py
+++ b/devices/Shuttle/shuttle/azure_messages.py
@@ -1,0 +1,15 @@
+from azure.iot.device import IoTHubDeviceClient
+import json
+
+class AzureMessageListener:
+
+    def __init__(self, connection_string):
+        self.connection_string = connection_string
+        self.device_client = IoTHubDeviceClient.create_from_connection_string(self.connection_string)
+
+        self.device_client.connect()
+
+    def message_listener(self):
+        message = self.device_client.receive_message()  # blocking call
+        jsonMsg = json.loads(message.data)
+        return jsonMsg['url'], jsonMsg['token']

--- a/devices/Shuttle/shuttle/azure_messages.py
+++ b/devices/Shuttle/shuttle/azure_messages.py
@@ -12,4 +12,4 @@ class AzureMessageListener:
     def message_listener(self):
         message = self.device_client.receive_message()  # blocking call
         jsonMsg = json.loads(message.data)
-        return jsonMsg['url'], jsonMsg['token']
+        return jsonMsg['url'], jsonMsg['authorization']

--- a/devices/Shuttle/shuttle/config.py
+++ b/devices/Shuttle/shuttle/config.py
@@ -8,6 +8,9 @@ load_dotenv()
 # String used for connection to azure iot hub
 IOTHUB_CONNECTION_STRING = os.getenv('IOTHUB_CONNECTION_STRING')
 
+# String used for device connection to Azure IoT Hub
+SHUTTLE_CONNECTION_STRING = os.getenv('SHUTTLE_CONNECTION_STRING')
+
 # URI of backend server websocket
 WEBSOCKET_URI = 'ws://localhost:3000/device/shuttle'
 #WEBSOCKET_URI = 'ws://localhost:3000/'

--- a/devices/Shuttle/shuttle/shuttle_connector.py
+++ b/devices/Shuttle/shuttle/shuttle_connector.py
@@ -228,7 +228,7 @@ class FakeShuttleConnector:
         '''Handles all websocket messages by running the appropriate method'''
 
         if message['type'] == 'input':
-            await self.send_thrust_command(message['x'], message['y'], message['y'], message['r'])
+            await self.send_thrust_command(message['x'], message['y'], message['z'], message['r'])
         elif message['type'] == 'changeFlightMode':
             await self.change_flight_mode(message['flightMode'])
         elif message['type'] == 'armShuttle':

--- a/devices/Shuttle/shuttle/shuttle_controller.py
+++ b/devices/Shuttle/shuttle/shuttle_controller.py
@@ -5,6 +5,7 @@ from time import time
 from shuttle import config
 from shuttle.websocket_connector import WebsocketConnector
 from shuttle.shuttle_connector import ShuttleConnector, FakeShuttleConnector
+from shuttle.azure_messages import AzureMessageListener
 
 
 logging.basicConfig(format='%(levelname)s: %(message)s', level=logging.INFO)
@@ -63,12 +64,15 @@ async def websocket_producer(shuttle_connector: ShuttleConnector):
 def control_over_websocket(use_fake_shuttle=False):
     ''' Main function for running the actual use case '''
 
+    azure_message_listener = AzureMessageListener(config.SHUTTLE_CONNECTION_STRING)
+    url, token = azure_message_listener.message_listener()
+
     # setup connections to backend and shuttle and create a desired_thrust object
     if use_fake_shuttle:
         shuttle_connector = FakeShuttleConnector()
     else:
         shuttle_connector = ShuttleConnector(config.MAVLINK_CONNECTION_STRING)
-    websocket_connector = WebsocketConnector(config.WEBSOCKET_URI)
+    websocket_connector = WebsocketConnector(url, token)
 
     async def main():
         # add functions that should be run concurrently

--- a/devices/Shuttle/shuttle/shuttle_controller.py
+++ b/devices/Shuttle/shuttle/shuttle_controller.py
@@ -5,7 +5,7 @@ from time import time
 from shuttle import config
 from shuttle.websocket_connector import WebsocketConnector
 from shuttle.shuttle_connector import ShuttleConnector, FakeShuttleConnector
-from shuttle.azure_messages import AzureMessageListener
+from shuttle.azure_messages import AzureMessages
 
 
 logging.basicConfig(format='%(levelname)s: %(message)s', level=logging.INFO)
@@ -64,8 +64,11 @@ async def websocket_producer(shuttle_connector: ShuttleConnector):
 def control_over_websocket(use_fake_shuttle=False):
     ''' Main function for running the actual use case '''
 
-    azure_message_listener = AzureMessageListener(config.SHUTTLE_CONNECTION_STRING)
-    url, token = azure_message_listener.message_listener()
+    azure_messages = AzureMessages(config.SHUTTLE_CONNECTION_STRING)
+    # Ask Azure IoT Hub for a bearer token
+    azure_messages.send_message('requestToken', '')
+    # Wait for the url and token to create websocket
+    url, token = azure_messages.message_listener()
 
     # setup connections to backend and shuttle and create a desired_thrust object
     if use_fake_shuttle:

--- a/devices/Shuttle/shuttle/websocket_connector.py
+++ b/devices/Shuttle/shuttle/websocket_connector.py
@@ -33,7 +33,7 @@ class WebsocketConnector:
 
     async def run(self):
         try: 
-            async with websockets.connect(self.uri) as websocket:
+            async with websockets.connect(self.uri, extra_headers = {'authorization':'token'}) as websocket:
                 await self.handler(websocket, websocket.path)
         except websockets.ConnectionClosed:
             logging.error('lost connection to websocket')

--- a/devices/Shuttle/shuttle/websocket_connector.py
+++ b/devices/Shuttle/shuttle/websocket_connector.py
@@ -21,8 +21,9 @@ class WebsocketConnector:
     3) run()
     '''
 
-    def __init__(self, uri):
+    def __init__(self, uri, token):
         self.uri: str = uri
+        self.token = token
 
     def get_shuttle_connector(self, shuttle_connector):
         self.shuttle_connector = shuttle_connector
@@ -33,7 +34,7 @@ class WebsocketConnector:
 
     async def run(self):
         try: 
-            async with websockets.connect(self.uri, extra_headers = {'authorization':'token'}) as websocket:
+            async with websockets.connect(self.uri, extra_headers = {'authorization': self.token}) as websocket:
                 await self.handler(websocket, websocket.path)
         except websockets.ConnectionClosed:
             logging.error('lost connection to websocket')


### PR DESCRIPTION
Devices that want to open a websocket connection to the server now need to have a bearer token, provided by the backend. The backend sends this bearer token upon request by the device through the Azure IoT Hub. 

To test this, you will need to register a device in your IoT Hub with device name `shuttle`, and provide your .env file with the device connection string. Also, remember to enable device authentication by setting `EITHUB_DISABLE_DEVICE_AUTH = "false"` in your .env file.